### PR TITLE
Update to match situation as of patch 6.84.

### DIFF
--- a/data/quiz.json
+++ b/data/quiz.json
@@ -89,7 +89,7 @@
       "a": "ability/venomancer_plague_ward"
     }, {
       "q": [ "ability/faceless_void_chronosphere", "ability/witch_doctor_death_ward" ],
-      "a": "ability/witch_doctor_death_ward"
+      "a": "ability/faceless_void_chronosphere"
     }, {
       "q": [ "ability/faceless_void_chronosphere", "item/butterfly" ],
       "a": "ability/faceless_void_chronosphere"
@@ -389,7 +389,7 @@
       "a": "item/black_king_bar"
     }, {
       "q": [ "item/black_king_bar", "ability/tinker_march_of_the_machines" ],
-      "a": "ability/tinker_march_of_the_machines"
+      "a": "item/black_king_bar"
     }, {
       "q": [ "item/black_king_bar", "ability/tiny_toss", "text/damage_blocked_only", "text/throw_blocked_only" ],
       "a": "text/damage_blocked_only"


### PR DESCRIPTION
Hi, just found your mechanics quiz today; it's cool, thanks for sharing!

Noticed two interactions that have been changed by recent patches since you wrote the app, one was a Tinker nerf to prevent ancient stacking, and the other was a Void buff:
- Tinker's march is now magic damage and is blocked by BKB.
  http://images.akamai.steamusercontent.com/ugc/683775440085475600/3928BE58C4D2025FFD35965CD8F939ADFC88649E/
- Chronosphere prevents witch doctor death ward from attacking if placed over the ward (and still cancels channelling completely if placed on witch doctor).
  http://images.akamai.steamusercontent.com/ugc/683775440085474812/B0CDFD8D969D7FFC477B13B4D754EB2C08B2898D/
